### PR TITLE
feat/github-action-docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,35 @@
+# Build and publish the Docker image to Docker Hub
+# Uses the official Docker action for this:
+#
+# https://github.com/marketplace/actions/build-and-push-docker-images
+#
+# Builds whenever a tag of the following format is pushed up: "1.0.0", "2.3.1", etc...
+
+name: ci
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: masterkale/docker-pgdump-s3:latest,MasterKale/docker-pgdump-s3:${{ GITHUB_REF }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
A GitHub action to build and publish the Docker image to Docker Hub. Based on the official Docker action:

https://github.com/marketplace/actions/build-and-push-docker-images

The action will be triggered whenever a tag of the following format is pushed up:
- "1.0.0"
- "2.3.1"